### PR TITLE
Fix dungeon select screen scrolling on mobile devices

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -773,7 +773,8 @@ body {
   align-items: center;
   gap: var(--spacing-xl);
   padding: var(--spacing-xl);
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
   background: linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-light) 100%);
 }
 
@@ -1508,6 +1509,7 @@ body {
   .dungeon-select-screen {
     padding: var(--spacing-md);
     gap: var(--spacing-md);
+    -webkit-overflow-scrolling: touch;
   }
 
   .dungeon-select-title {


### PR DESCRIPTION
## Summary
Fixed scrolling behavior on the dungeon select screen to properly handle overflow content on mobile devices and improve the user experience on smaller viewports.

## Key Changes
- Changed `.dungeon-select-screen` from `min-height: 100vh` to `height: 100vh` with `overflow-y: auto` to enable scrolling when content exceeds viewport height
- Added `-webkit-overflow-scrolling: touch` to mobile media query for smooth momentum scrolling on iOS devices

## Implementation Details
The previous implementation used `min-height: 100vh` which could cause content to overflow without proper scrolling capabilities. By switching to `height: 100vh` with `overflow-y: auto`, the container now properly constrains its height while allowing vertical scrolling when needed. The `-webkit-overflow-scrolling: touch` property enhances the scrolling experience on iOS by enabling hardware-accelerated momentum scrolling, providing a more native feel on mobile devices.

https://claude.ai/code/session_0155CHquHWP7YRemMEhc9DVd