### PR TITLE
スマホ画面でのスキルツリーがスクロールできない問題を修正

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1056,7 +1056,8 @@ body {
   align-items: center;
   gap: var(--spacing-lg);
   padding: var(--spacing-xl);
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
   background: linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-light) 100%);
 }
 
@@ -1503,6 +1504,40 @@ body {
 
   .title-controls {
     display: none;
+  }
+
+  /* スキルツリーのモバイル調整 */
+  .skill-tree-screen {
+    padding: var(--spacing-md);
+    gap: var(--spacing-md);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .skill-tree-title {
+    font-size: 24px;
+  }
+
+  .skill-tree-header {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+
+  .skill-tree-branches {
+    flex-direction: column;
+    gap: var(--spacing-md);
+    width: 100%;
+    align-items: center;
+  }
+
+  .skill-branch {
+    width: 100%;
+    max-width: 320px;
+    min-width: unset;
+    padding: var(--spacing-md);
+  }
+
+  .skill-card {
+    width: 120px;
   }
 
   /* ダンジョン選択のモバイル調整 */


### PR DESCRIPTION
## Summary
This PR improves the skill tree screen's scrolling behavior and adds comprehensive mobile responsiveness adjustments to ensure proper display on smaller devices.

## Key Changes
- Changed skill tree screen from `min-height: 100vh` to `height: 100vh` with `overflow-y: auto` to enable proper scrolling when content exceeds viewport height
- Added mobile-specific styling for the skill tree screen with reduced padding and gap spacing
- Implemented responsive layout adjustments for skill tree components:
  - Converted skill tree header and branches to column layout on mobile
  - Set skill branches to full width with max-width constraint (320px)
  - Adjusted skill card width to 120px for mobile display
- Added `-webkit-overflow-scrolling: touch` for smooth momentum scrolling on iOS devices

## Implementation Details
- All mobile adjustments are contained within the existing media query breakpoint
- Spacing uses existing CSS variables for consistency
- Changes maintain the visual hierarchy while optimizing for smaller screens
- The overflow-y auto approach allows content to scroll naturally when needed while maintaining the full viewport height baseline

https://claude.ai/code/session_01RD6AxN3GqZaEug3Y6EC8w9