### PR TITLE
攻撃の空振りを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import type { Direction } from './types';
 import type { DungeonId } from './data/dungeons/index';
 
 function App() {
-  const { state, movePlayer, toggleInventory, toggleGodMode, fullHeal, nextFloor, startGame, setPhase } = useGameStore();
+  const { state, movePlayer, attackInPlace, toggleInventory, toggleGodMode, fullHeal, nextFloor, startGame, setPhase } = useGameStore();
   const { debug, toggleDebug, toggleFullMap } = useDebugStore();
   const { phase } = state;
 
@@ -168,6 +168,11 @@ function App() {
         case 'Enter':
           descendStairs();
           return;
+        // 攻撃（向いている方向に攻撃/空振り）
+        case ' ':
+          e.preventDefault();
+          attackInPlace();
+          return;
       }
 
       if (direction) {
@@ -189,7 +194,7 @@ function App() {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [phase, movePlayer, toggleInventory, debug.enabled, toggleDebug, toggleFullMap, toggleGodMode, fullHeal, nextFloor]);
+  }, [phase, movePlayer, attackInPlace, toggleInventory, debug.enabled, toggleDebug, toggleFullMap, toggleGodMode, fullHeal, nextFloor]);
 
   // モバイルD-Pad操作ハンドラ
   const handleMobileDirection = useCallback((direction: Direction) => {
@@ -198,13 +203,15 @@ function App() {
     }
   }, [phase, movePlayer]);
 
-  const handleMobileAction = useCallback((action: 'stairs' | 'inventory') => {
-    if (action === 'stairs') {
+  const handleMobileAction = useCallback((action: 'stairs' | 'inventory' | 'attack') => {
+    if (action === 'attack') {
+      attackInPlace();
+    } else if (action === 'stairs') {
       descendStairs();
     } else if (action === 'inventory') {
       toggleInventory();
     }
-  }, [toggleInventory]);
+  }, [attackInPlace, toggleInventory]);
 
   // ダンジョン選択ハンドラ
   const handleSelectDungeon = (dungeonId: DungeonId) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,8 @@ function App() {
           return;
         // 攻撃（向いている方向に攻撃/空振り）
         case ' ':
+        case 'z':
+        case 'Z':
           e.preventDefault();
           attackInPlace();
           return;

--- a/src/components/MobileDPad.tsx
+++ b/src/components/MobileDPad.tsx
@@ -5,7 +5,7 @@ import type { Direction } from '../types';
 
 interface MobileDPadProps {
     onDirection: (direction: Direction) => void;
-    onAction: (action: 'stairs' | 'inventory') => void;
+    onAction: (action: 'stairs' | 'inventory' | 'attack') => void;
 }
 
 export function MobileDPad({ onDirection, onAction }: MobileDPadProps) {
@@ -70,6 +70,13 @@ export function MobileDPad({ onDirection, onAction }: MobileDPadProps) {
                 </div>
             </div>
             <div className="action-buttons">
+                <button
+                    className="action-btn action-btn-attack"
+                    onTouchStart={(e) => { e.preventDefault(); onAction('attack'); }}
+                    onClick={() => onAction('attack')}
+                >
+                    攻撃
+                </button>
                 <button
                     className="action-btn action-btn-stairs"
                     onTouchStart={(e) => { e.preventDefault(); onAction('stairs'); }}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -54,6 +54,7 @@ interface GameStore {
 
     // プレイヤー操作
     movePlayer: (direction: Direction) => void;
+    attackInPlace: () => void;
     useItem: (itemIndex: number) => void;
     toggleInventory: () => void;
 
@@ -391,6 +392,96 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
             // 視界を更新
             computeVisibility(floor, newPosition);
+        }
+
+        // 敵のターンを処理
+        processEnemyTurn();
+
+        // ターンカウント増加
+        set((s) => ({
+            state: {
+                ...s.state,
+                turnCount: s.state.turnCount + 1,
+            },
+        }));
+    },
+
+    attackInPlace: () => {
+        const { state, processEnemyTurn, addMessage } = get();
+        if (state.phase !== 'playing' || !state.player || !state.floor) return;
+
+        const { player, enemies } = state;
+        const { x, y } = player.position;
+        const direction = player.direction;
+
+        // 向いている方向のターゲット座標を計算
+        let targetX = x;
+        let targetY = y;
+        switch (direction) {
+            case 'up': targetY--; break;
+            case 'down': targetY++; break;
+            case 'left': targetX--; break;
+            case 'right': targetX++; break;
+            case 'up-left': targetX--; targetY--; break;
+            case 'up-right': targetX++; targetY--; break;
+            case 'down-left': targetX--; targetY++; break;
+            case 'down-right': targetX++; targetY++; break;
+        }
+
+        // ターゲット座標に敵がいるかチェック
+        const targetEnemy = enemies.find(
+            (e) => e.position.x === targetX && e.position.y === targetY
+        );
+
+        if (targetEnemy) {
+            // 敵に攻撃
+            const damage = Math.max(1, player.attack - targetEnemy.defense);
+            targetEnemy.hp -= damage;
+
+            get().addAttackEffect(targetEnemy.position, direction);
+            addMessage(`${targetEnemy.name}に${damage}のダメージ！`);
+
+            if (targetEnemy.hp <= 0) {
+                addMessage(`${targetEnemy.name}を倒した！`);
+
+                const newExp = player.exp + targetEnemy.expReward;
+                let newPlayer = { ...player, exp: newExp };
+
+                if (
+                    newPlayer.level < EXP_TABLE.length &&
+                    newExp >= EXP_TABLE[newPlayer.level]
+                ) {
+                    newPlayer.level++;
+                    newPlayer.maxHp += LEVEL_UP_BONUS.hp;
+                    newPlayer.hp = newPlayer.maxHp;
+                    newPlayer.attack += LEVEL_UP_BONUS.attack;
+                    newPlayer.defense += LEVEL_UP_BONUS.defense;
+                    newPlayer.expToNext =
+                        EXP_TABLE[newPlayer.level] || EXP_TABLE[EXP_TABLE.length - 1];
+                    addMessage(`レベルアップ！レベル${newPlayer.level}になった！`);
+                }
+
+                set((s) => ({
+                    state: {
+                        ...s.state,
+                        player: newPlayer,
+                        enemies: s.state.enemies.filter((e) => e.id !== targetEnemy.id),
+                    },
+                }));
+            } else {
+                set((s) => ({
+                    state: {
+                        ...s.state,
+                        enemies: s.state.enemies.map((e) =>
+                            e.id === targetEnemy.id ? targetEnemy : e
+                        ),
+                    },
+                }));
+            }
+        } else {
+            // 空振り
+            get().addAttackEffect({ x: targetX, y: targetY }, direction);
+            addMessage('空振りした！');
         }
 
         // 敵のターンを処理

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -479,9 +479,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
                 }));
             }
         } else {
-            // 空振り
+            // 空振り（メッセージなしでターンを進める）
             get().addAttackEffect({ x: targetX, y: targetY }, direction);
-            addMessage('空振りした！');
         }
 
         // 敵のターンを処理


### PR DESCRIPTION
## Summary
This PR implements an in-place attack system that allows players to attack enemies in the direction they are facing without moving. The feature is accessible via keyboard (Space/Z keys) and a new mobile UI button.

## Key Changes
- **Game State**: Added `attackInPlace()` action to `GameStore` that:
  - Calculates target coordinates based on player's current direction
  - Detects enemies at the target location
  - Applies damage calculation (player attack - enemy defense)
  - Handles enemy defeat with experience rewards and level-up logic
  - Displays attack effects and messages
  - Processes enemy turn and increments turn counter
  - Supports empty attacks (no message) when no enemy is present

- **Keyboard Controls**: Added Space and Z key bindings to trigger `attackInPlace()`

- **Mobile UI**: 
  - Added "攻撃" (Attack) button to the mobile D-Pad component
  - Updated action handler to support 'attack' action type
  - Button supports both touch and click events

- **Type Updates**: Updated `MobileDPadProps` interface to include 'attack' in the action union type

## Implementation Details
- Attack damage is calculated as `max(1, player.attack - enemy.defense)` to ensure minimum 1 damage
- Level-up system is triggered when experience reaches the threshold for the next level
- Attack effects are rendered at the target position regardless of hit/miss
- Enemy turn processing occurs after the attack action completes

https://claude.ai/code/session_013ygjcBSqCX7EczfG24XAXp